### PR TITLE
Fix broken code in the AST parsing code

### DIFF
--- a/R/extract_geoms.R
+++ b/R/extract_geoms.R
@@ -69,8 +69,8 @@ find_geom_calls_in_parsed_code <- function(expr, geom_names) {
       }
     } else if (is.list(e) || is.expression(e)) {
       # Recursively search within list/expression
-      for (item in e) {
-        find_calls_recursive(item)
+      for (i in seq_along(e)) {
+        find_calls_recursive(e[[i]])
       }
     }
   }

--- a/R/extract_geoms.R
+++ b/R/extract_geoms.R
@@ -39,6 +39,60 @@ read_code_from_file <- function(file_path) {
   }
 }
 
+#' Extract a complete function call from text
+#'
+#' Helper to extract a complete function call by matching parentheses
+#'
+#' @param text Character string containing code
+#' @param start_pos Position where the opening ( appears
+#' @returns Character string with the complete call, or NULL if can't extract
+#' @keywords internal
+extract_complete_call <- function(text, start_pos) {
+  chars <- strsplit(text, "")[[1]]
+  depth <- 0
+  in_string <- FALSE
+  string_char <- NULL
+  escape_next <- FALSE
+
+  for (i in start_pos:length(chars)) {
+    char <- chars[i]
+
+    # Handle escape sequences
+    if (escape_next) {
+      escape_next <- FALSE
+      next
+    }
+    if (char == "\\" && in_string) {
+      escape_next <- TRUE
+      next
+    }
+
+    # Handle string boundaries
+    if (char %in% c("'", '"') && !in_string) {
+      in_string <- TRUE
+      string_char <- char
+    } else if (char == string_char && in_string) {
+      in_string <- FALSE
+      string_char <- NULL
+    }
+
+    # Track parenthesis depth (only when not in string)
+    if (!in_string) {
+      if (char == "(") depth <- depth + 1
+      if (char == ")") {
+        depth <- depth - 1
+        if (depth == 0) {
+          # Found the closing paren
+          return(paste(chars[start_pos:i], collapse = ""))
+        }
+      }
+    }
+  }
+
+  # Couldn't find matching closing paren
+  return(NULL)
+}
+
 #' Find geom calls via pattern matching
 #'
 #' Fallback function to find geom usage via string pattern matching
@@ -50,18 +104,68 @@ read_code_from_file <- function(file_path) {
 #' @returns A tibble with geom usage info (limited detail since parsing failed)
 #' @keywords internal
 find_geoms_by_pattern <- function(code_text, geom_names, geoms_dataset) {
-  # Search for each geom name followed by opening parenthesis
-  found_geoms <- character(0)
+  # Search for each geom name and try to extract full calls
+  results <- list()
 
   for (geom in geom_names) {
     # Pattern: geom name followed by optional whitespace and (
     pattern <- paste0(geom, "\\s*\\(")
-    if (stringr::str_detect(code_text, pattern)) {
-      found_geoms <- c(found_geoms, geom)
+    matches <- gregexpr(pattern, code_text)[[1]]
+
+    if (matches[1] != -1) {
+      for (match_pos in matches) {
+        # Find where the opening parenthesis is
+        substr_after <- substring(code_text, match_pos)
+        paren_pos <- regexpr("\\(", substr_after)
+        if (paren_pos > 0) {
+          # Extract complete call starting from the (
+          call_from_paren <- extract_complete_call(code_text, match_pos + paren_pos - 1)
+
+          if (!is.null(call_from_paren)) {
+            # Reconstruct full call with geom name
+            full_call <- paste0(geom, call_from_paren)
+
+            # Try to parse this individual call to extract details
+            parsed_call <- tryCatch(
+              parse(text = full_call),
+              error = function(e) NULL
+            )
+
+            if (!is.null(parsed_call)) {
+              # We can parse it! Extract detailed info
+              func_call_details <- extract_geom_arguments(full_call)[[1]]
+              has_aes <- if (nrow(func_call_details) > 0) {
+                any(func_call_details$is_aes)
+              } else {
+                FALSE
+              }
+              n_args <- nrow(func_call_details)
+              length_call <- stringr::str_length(stringr::str_remove(full_call, geom)) - 2
+
+              results[[length(results) + 1]] <- list(
+                geom_name = geom,
+                has_aes = has_aes,
+                function_call = func_call_details,
+                length_of_call = length_call,
+                n_args_in_call = n_args
+              )
+            } else {
+              # Can't parse the individual call either
+              results[[length(results) + 1]] <- list(
+                geom_name = geom,
+                has_aes = NA,
+                function_call = NULL,
+                length_of_call = NA_real_,
+                n_args_in_call = NA_real_
+              )
+            }
+          }
+        }
+      }
     }
   }
 
-  if (length(found_geoms) == 0) {
+  if (length(results) == 0) {
     # No geoms found, return empty result
     empty_result <- tibble::tibble(
       geom_name = character(0),
@@ -75,15 +179,19 @@ find_geoms_by_pattern <- function(code_text, geom_names, geoms_dataset) {
     return(dplyr::add_row(empty_result))
   }
 
-  # Create result with limited info (can't extract full details from unparseable code)
-  tibble::tibble(geom_name = found_geoms) |>
-    dplyr::mutate(
-      has_aes = NA,
-      function_call = list(NULL),
-      length_of_call = NA_real_,
-      n_args_in_call = NA_real_,
-      n_times_used = 1L
-    ) |>
+  # Convert to tibble
+  result_df <- tibble::tibble(
+    geom_name = purrr::map_chr(results, "geom_name"),
+    has_aes = purrr::map(results, "has_aes") |> unlist(),
+    length_of_call = purrr::map_dbl(results, "length_of_call"),
+    n_args_in_call = purrr::map_dbl(results, "n_args_in_call")
+  )
+
+  # Add function_call as a list column
+  result_df$function_call <- purrr::map(results, "function_call")
+
+  result_df |>
+    dplyr::mutate(n_times_used = dplyr::n(), .by = geom_name) |>
     dplyr::left_join(
       dplyr::select(geoms_dataset, geom_name, package_name),
       by = "geom_name"

--- a/R/extract_geoms.R
+++ b/R/extract_geoms.R
@@ -123,7 +123,25 @@ get_geoms_from_code_file <- function(file_path, geoms_dataset) {
   get_geoms_from_code_file_singular <- function(file_path) {
     code_file <- read_code_from_file(file_path)
 
-    parsed_code <- parse(text = code_file)
+    # Try to parse the code - if it fails (syntax error), return empty result
+    parsed_code <- tryCatch(
+      parse(text = code_file),
+      error = function(e) NULL
+    )
+
+    # If parsing failed, return empty result
+    if (is.null(parsed_code)) {
+      empty_result <- tibble::tibble(
+        geom_name = character(0),
+        has_aes = logical(0),
+        function_call = list(),
+        length_of_call = numeric(0),
+        n_args_in_call = numeric(0),
+        n_times_used = integer(0),
+        package_name = character(0)
+      )
+      return(dplyr::add_row(empty_result))
+    }
 
     # Get list of geom names to search for
     vec_geoms <- dplyr::pull(geoms_dataset, geom_name)

--- a/R/extract_geoms.R
+++ b/R/extract_geoms.R
@@ -57,7 +57,7 @@ find_geom_calls_in_parsed_code <- function(expr, geom_names) {
     if (is.call(e)) {
       # Check if this is a function call we're looking for
       func_name <- as.character(e[[1]])
-      if (func_name %in% geom_names) {
+      if (length(func_name) == 1 && func_name %in% geom_names) {
         # Deparse to get the full text of the call
         call_text <- paste(deparse(e), collapse = " ")
         # Add to results

--- a/R/extract_geoms.R
+++ b/R/extract_geoms.R
@@ -39,6 +39,57 @@ read_code_from_file <- function(file_path) {
   }
 }
 
+#' Find geom calls via pattern matching
+#'
+#' Fallback function to find geom usage via string pattern matching
+#' when code cannot be parsed due to syntax errors
+#'
+#' @param code_text Character string containing the code
+#' @param geom_names Character vector of geom names to search for
+#' @param geoms_dataset The geoms dataset for package info
+#' @returns A tibble with geom usage info (limited detail since parsing failed)
+#' @keywords internal
+find_geoms_by_pattern <- function(code_text, geom_names, geoms_dataset) {
+  # Search for each geom name followed by opening parenthesis
+  found_geoms <- character(0)
+
+  for (geom in geom_names) {
+    # Pattern: geom name followed by optional whitespace and (
+    pattern <- paste0(geom, "\\s*\\(")
+    if (stringr::str_detect(code_text, pattern)) {
+      found_geoms <- c(found_geoms, geom)
+    }
+  }
+
+  if (length(found_geoms) == 0) {
+    # No geoms found, return empty result
+    empty_result <- tibble::tibble(
+      geom_name = character(0),
+      has_aes = logical(0),
+      function_call = list(),
+      length_of_call = numeric(0),
+      n_args_in_call = numeric(0),
+      n_times_used = integer(0),
+      package_name = character(0)
+    )
+    return(dplyr::add_row(empty_result))
+  }
+
+  # Create result with limited info (can't extract full details from unparseable code)
+  tibble::tibble(geom_name = found_geoms) |>
+    dplyr::mutate(
+      has_aes = NA,
+      function_call = list(NULL),
+      length_of_call = NA_real_,
+      n_args_in_call = NA_real_,
+      n_times_used = 1L
+    ) |>
+    dplyr::left_join(
+      dplyr::select(geoms_dataset, geom_name, package_name),
+      by = "geom_name"
+    )
+}
+
 #' Find geom calls
 #'
 #' Helper function to recursively find geom function calls in parsed R code
@@ -123,28 +174,19 @@ get_geoms_from_code_file <- function(file_path, geoms_dataset) {
   get_geoms_from_code_file_singular <- function(file_path) {
     code_file <- read_code_from_file(file_path)
 
-    # Try to parse the code - if it fails (syntax error), return empty result
+    # Get list of geom names to search for
+    vec_geoms <- dplyr::pull(geoms_dataset, geom_name)
+
+    # Try to parse the code - if it fails (syntax error), fall back to pattern matching
     parsed_code <- tryCatch(
       parse(text = code_file),
       error = function(e) NULL
     )
 
-    # If parsing failed, return empty result
+    # If parsing failed, use pattern matching fallback
     if (is.null(parsed_code)) {
-      empty_result <- tibble::tibble(
-        geom_name = character(0),
-        has_aes = logical(0),
-        function_call = list(),
-        length_of_call = numeric(0),
-        n_args_in_call = numeric(0),
-        n_times_used = integer(0),
-        package_name = character(0)
-      )
-      return(dplyr::add_row(empty_result))
+      return(find_geoms_by_pattern(code_file, vec_geoms, geoms_dataset))
     }
-
-    # Get list of geom names to search for
-    vec_geoms <- dplyr::pull(geoms_dataset, geom_name)
 
     geom_calls <- find_geom_calls_in_parsed_code(parsed_code, vec_geoms)
 

--- a/tests/testthat/dummy_brace_in_string.R
+++ b/tests/testthat/dummy_brace_in_string.R
@@ -1,0 +1,3 @@
+grid::rasterGrob(png::readPNG(glue("www/icon_{skill_as_path}.png")), interpolate = TRUE)
+
+

--- a/tests/testthat/dummy_invalid_code.R
+++ b/tests/testthat/dummy_invalid_code.R
@@ -1,0 +1,2 @@
+foobar <- =("some_argument") %>%
+  some_fn()

--- a/tests/testthat/dummy_invalid_with_detailed_geom.R
+++ b/tests/testthat/dummy_invalid_with_detailed_geom.R
@@ -1,0 +1,2 @@
+foobar <- =("some_argument") %>%
+  geom_point(aes(x = foo, y = bar), color = "red", size = 3)

--- a/tests/testthat/dummy_invalid_with_geom.R
+++ b/tests/testthat/dummy_invalid_with_geom.R
@@ -1,0 +1,2 @@
+foobar <- =("some_argument") %>%
+  geom_point()

--- a/tests/testthat/test-get_file_info.R
+++ b/tests/testthat/test-get_file_info.R
@@ -10,9 +10,22 @@ na_df <- tibble::tibble(
     package_name = NA_character_
   )
 
-test_that("get_geoms_from_code_file works with file containing geoms", {
+test_that("get_geoms_from_code_file works with {{ }}", {
   result <- get_geoms_from_code_file(
     testthat::test_path("dummy_breaking_code.R"),
+    data_geoms
+  )
+
+  result_df <- result[[1]]
+
+  expect_equal(result_df, na_df)
+
+}
+)
+
+test_that("get_geoms_from_code_file works with { in strings", {
+  result <- get_geoms_from_code_file(
+    testthat::test_path("dummy_brace_in_string.R"),
     data_geoms
   )
 

--- a/tests/testthat/test-get_file_info.R
+++ b/tests/testthat/test-get_file_info.R
@@ -62,11 +62,37 @@ test_that("get_geoms_from_code_file detects geoms in invalid code via pattern ma
   expect_equal(result_df$geom_name, "geom_point")
   expect_equal(result_df$package_name, "ggplot2")
 
-  # Detailed info should be NA since we couldn't parse the code
-  expect_true(is.na(result_df$has_aes))
-  expect_true(is.na(result_df$length_of_call))
-  expect_true(is.na(result_df$n_args_in_call))
+  # Since geom_point() is a valid call, we should extract details
+  expect_equal(result_df$has_aes, FALSE)
+  expect_equal(result_df$length_of_call, 0)
+  expect_equal(result_df$n_args_in_call, 0)
   expect_equal(result_df$n_times_used, 1L)
+}
+)
+
+test_that("get_geoms_from_code_file extracts details from valid geom calls in invalid code", {
+  result <- get_geoms_from_code_file(
+    testthat::test_path("dummy_invalid_with_detailed_geom.R"),
+    data_geoms
+  )
+
+  result_df <- result[[1]]
+
+  # Should detect geom_point and extract full details
+  expect_equal(nrow(result_df), 1)
+  expect_equal(result_df$geom_name, "geom_point")
+  expect_equal(result_df$package_name, "ggplot2")
+
+  # Should extract detailed info since the geom call itself is valid
+  expect_equal(result_df$has_aes, TRUE)
+  expect_equal(result_df$n_args_in_call, 3)
+  expect_equal(result_df$n_times_used, 1L)
+
+  # Check the function_call details
+  func_call <- result_df$function_call[[1]]
+  expect_equal(nrow(func_call), 3)
+  expect_equal(func_call$is_aes, c(FALSE, FALSE, TRUE))
+  expect_equal(func_call$argument_name, c("color", "size", ""))
 }
 )
 

--- a/tests/testthat/test-get_file_info.R
+++ b/tests/testthat/test-get_file_info.R
@@ -36,6 +36,19 @@ test_that("get_geoms_from_code_file works with { in strings", {
 }
 )
 
+test_that("get_geoms_from_code_file works with invalid code", {
+  result <- get_geoms_from_code_file(
+    testthat::test_path("dummy_invalid_code.R"),
+    data_geoms
+  )
+
+  result_df <- result[[1]]
+
+  expect_equal(result_df, na_df)
+
+}
+)
+
 
 test_that("get_geoms_from_code_file works with file containing geoms", {
   result <- get_geoms_from_code_file(

--- a/tests/testthat/test-get_file_info.R
+++ b/tests/testthat/test-get_file_info.R
@@ -49,6 +49,27 @@ test_that("get_geoms_from_code_file works with invalid code", {
 }
 )
 
+test_that("get_geoms_from_code_file detects geoms in invalid code via pattern matching", {
+  result <- get_geoms_from_code_file(
+    testthat::test_path("dummy_invalid_with_geom.R"),
+    data_geoms
+  )
+
+  result_df <- result[[1]]
+
+  # Should detect geom_point even though code has syntax error
+  expect_equal(nrow(result_df), 1)
+  expect_equal(result_df$geom_name, "geom_point")
+  expect_equal(result_df$package_name, "ggplot2")
+
+  # Detailed info should be NA since we couldn't parse the code
+  expect_true(is.na(result_df$has_aes))
+  expect_true(is.na(result_df$length_of_call))
+  expect_true(is.na(result_df$n_args_in_call))
+  expect_equal(result_df$n_times_used, 1L)
+}
+)
+
 
 test_that("get_geoms_from_code_file works with file containing geoms", {
   result <- get_geoms_from_code_file(


### PR DESCRIPTION
All tests now pass for me!

Below is Claude output

______________________


The issue was in the `find_calls_recursive` function in R/extract_geoms.R:72-74. The function had an inconsistent looping pattern:

  - For calls, it used `for (i in seq_along(e)) with e[[i]]`
  - For lists/expressions, it used `for (item in e)` with `item`

When the parser encountered rlang's curly-curly operator (`{{ start_col }}`) in the test file, it created a special expression structure that caused  scoping issues with the second loop pattern, resulting in the "argument 'item' is missing" error.

Fix: Changed the list/expression loop to use the same `seq_along()` pattern as the call loop, making both approaches consistent and avoiding scoping  issues with complex R expression types.